### PR TITLE
Resolvido erro de pastas com espaços no nome.

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,6 +52,9 @@ function render(tray = mainTray) {
       {
         label: locale.open,
         click: () => {
+          if (basename(path).split(' ').length > 1) {
+            path = `"${path}"`
+          }
           spawn('code', [path], { shell: true });
         },
       },


### PR DESCRIPTION
#### Resolvido erro quando a pasta tinha nome com espaço ex: 'Source Codes'.

Ambiente de bug: Windows 10.

Como foi resolvido: Foi adicionado aspas duplas em volta do diretório da pasta, no windows isso resolve, não tenho mac ou linux aqui para testar em outros SO.


Obs: Minha primeira pull request galera, não sei se está tudo certo, caso não esteja me falem por favor

Analisa ai @diego3g hehe 

